### PR TITLE
Initial set of fixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,6 @@ env:
   GOLANGCI_LINT_CACHE: /home/runner/go/cache/lint
   GOMODCACHE: /home/runner/go/mod
   GOPROXY: https://proxy.golang.org
-  TIGRIS_DOCKERFILE: tigris_main
 
 jobs:
   test:
@@ -38,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "Tigris", task: "tigris" }
+          - { name: "Tigris", task: "tigris", tigris_dockerfile: "tigris_main" }
 
     steps:
       - name: Checkout code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,7 @@ env:
   GORACE: halt_on_error=1,history_size=2
 
 vars:
-  INTEGRATIONTIME: 15m
+  INTEGRATIONTIME: 25m
   BENCHTIME: 5s
   FUZZTIME: 15s
   FUZZCORPUS: ../fuzz-corpus
@@ -66,7 +66,7 @@ tasks:
     cmds:
       - >
         docker compose up --always-recreate-deps --force-recreate --remove-orphans --renew-anon-volumes --timeout=0 --detach
-        --build --pull=always
+        --build
         {{.SERVICES}}
 
   env-up-detach-offline:
@@ -327,8 +327,8 @@ tasks:
   lint:
     desc: "Run linters"
     cmds:
-      - bin/golangci-lint{{exeExt}} run --config=.golangci.yml
-      - bin/golangci-lint{{exeExt}} run --config=.golangci-new.yml
+      - bin/golangci-lint{{exeExt}} run --fix --config=.golangci.yml
+      - bin/golangci-lint{{exeExt}} run --fix --config=.golangci-new.yml
       - bin/go-consistent{{exeExt}} -pedantic ./cmd/... ./internal/... ./build/... ./ferretdb/...
       - bin/go-sumtype{{exeExt}} ./...
       - go vet -vettool=./bin/checkswitch{{exeExt}} ./...

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0
 	github.com/stretchr/testify v1.8.2
-	github.com/tigrisdata/tigris-client-go v1.0.0-beta.24
+	github.com/tigrisdata/tigris-client-go v1.0.0-beta.25
 	go.opentelemetry.io/otel v1.14.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.7.0 // indirect; always use @latest

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.24 h1:lPR3MiP+RqNdNbjRU2JDXoj/j8v2ZFWpjCSVyaA+OA8=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.24/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.25 h1:ifJlt67uoyprSJYWaOvd1aTkOL/FxpEBXcxv7n8ASOs=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.25/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=

--- a/integration/commands_diagnostic_test.go
+++ b/integration/commands_diagnostic_test.go
@@ -186,7 +186,7 @@ func TestCommandsDiagnosticGetLog(t *testing.T) {
 
 			var actual bson.D
 			err := collection.Database().RunCommand(ctx, tc.command).Decode(&actual)
-			if err != nil {
+			if tc.err != nil {
 				AssertEqualAltError(t, *tc.err, tc.alt, err)
 				return
 			}

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -291,16 +291,6 @@ func TestCreateTigris(t *testing.T) {
 		expectedErr *mongo.CommandError
 		doc         bson.D
 	}{
-		"BadValidator": {
-			validator:  "$bad",
-			schema:     "{}",
-			collection: collection.Name() + "wrong",
-			expectedErr: &mongo.CommandError{
-				Code:    2,
-				Name:    "BadValue",
-				Message: `required parameter "$tigrisSchemaString" is missing`,
-			},
-		},
 		"EmptySchema": {
 			validator:  "$tigrisSchemaString",
 			schema:     "",

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/tigrisdata/tigris-client-go v1.0.0-beta.24 // indirect
+	github.com/tigrisdata/tigris-client-go v1.0.0-beta.25 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -270,8 +270,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.24 h1:lPR3MiP+RqNdNbjRU2JDXoj/j8v2ZFWpjCSVyaA+OA8=
-github.com/tigrisdata/tigris-client-go v1.0.0-beta.24/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.25 h1:ifJlt67uoyprSJYWaOvd1aTkOL/FxpEBXcxv7n8ASOs=
+github.com/tigrisdata/tigris-client-go v1.0.0-beta.25/go.mod h1:sT5YZVA9AwI31vIKv0WHqOQYE9pi41HDQ2GDHBo4i3s=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=

--- a/integration/query_compat_test.go
+++ b/integration/query_compat_test.go
@@ -75,6 +75,7 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 			}
 
 			var nonEmptyResults bool
+			var notAllSkipped bool
 			for i := range targetCollections {
 				targetCollection := targetCollections[i]
 				compatCollection := compatCollections[i]
@@ -128,16 +129,20 @@ func testQueryCompat(t *testing.T, testCases map[string]queryCompatTestCase) {
 					if len(targetRes) > 0 || len(compatRes) > 0 {
 						nonEmptyResults = true
 					}
+
+					notAllSkipped = true
 				})
 			}
 
-			switch tc.resultType {
-			case nonEmptyResult:
-				assert.True(t, nonEmptyResults, "expected non-empty results")
-			case emptyResult:
-				assert.False(t, nonEmptyResults, "expected empty results")
-			default:
-				t.Fatalf("unknown result type %v", tc.resultType)
+			if notAllSkipped {
+				switch tc.resultType {
+				case nonEmptyResult:
+					assert.True(t, nonEmptyResults, "expected non-empty results")
+				case emptyResult:
+					assert.False(t, nonEmptyResults, "expected empty results")
+				default:
+					t.Fatalf("unknown result type %v", tc.resultType)
+				}
 			}
 		})
 	}

--- a/integration/update_array_compat_test.go
+++ b/integration/update_array_compat_test.go
@@ -89,7 +89,8 @@ func TestUpdateArrayCompatPush(t *testing.T) {
 			resultType: emptyResult, // conflict because of duplicate keys "v" set in $push
 		},
 		"String": {
-			update: bson.D{{"$push", bson.D{{"v", "foo"}}}},
+			update:        bson.D{{"$push", bson.D{{"v", "foo"}}}},
+			skipForTigris: "Tigris does not support arrays with different element types",
 		},
 		"Int32": {
 			update:        bson.D{{"$push", bson.D{{"v", int32(42)}}}},
@@ -132,7 +133,8 @@ func TestUpdateArrayCompatAddToSet(t *testing.T) {
 			resultType: emptyResult,
 		},
 		"String": {
-			update: bson.D{{"$addToSet", bson.D{{"v", "foo"}}}},
+			update:        bson.D{{"$addToSet", bson.D{{"v", "foo"}}}},
+			skipForTigris: "Tigris does not support adding new array elements with different types",
 		},
 		"Document": {
 			update:        bson.D{{"$addToSet", bson.D{{"v", bson.D{{"foo", "bar"}}}}}},

--- a/integration/update_compat_test.go
+++ b/integration/update_compat_test.go
@@ -81,6 +81,7 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 			}
 
 			var nonEmptyResults bool
+			var notAllSkipped bool
 			for i := range targetCollections {
 				targetCollection := targetCollections[i]
 				compatCollection := compatCollections[i]
@@ -140,18 +141,22 @@ func testUpdateCompat(t *testing.T, testCases map[string]updateCompatTestCase) {
 							require.NoError(t, targetCollection.FindOne(ctx, bson.D{{"_id", id}}).Decode(&targetFindRes))
 							require.NoError(t, compatCollection.FindOne(ctx, bson.D{{"_id", id}}).Decode(&compatFindRes))
 							AssertEqualDocuments(t, compatFindRes, targetFindRes)
+
+							notAllSkipped = true
 						})
 					}
 				})
 			}
 
-			switch tc.resultType {
-			case nonEmptyResult:
-				assert.True(t, nonEmptyResults, "expected non-empty results (some documents should be modified)")
-			case emptyResult:
-				assert.False(t, nonEmptyResults, "expected empty results (no documents should be modified)")
-			default:
-				t.Fatalf("unknown result type %v", tc.resultType)
+			if notAllSkipped {
+				switch tc.resultType {
+				case nonEmptyResult:
+					assert.True(t, nonEmptyResults, "expected non-empty results (some documents should be modified)")
+				case emptyResult:
+					assert.False(t, nonEmptyResults, "expected empty results (no documents should be modified)")
+				default:
+					t.Fatalf("unknown result type %v", tc.resultType)
+				}
 			}
 		})
 	}

--- a/internal/handlers/tigris/msg_drop.go
+++ b/internal/handlers/tigris/msg_drop.go
@@ -53,15 +53,16 @@ func (h *Handler) MsgDrop(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, er
 		return nil, err
 	}
 
+	collection = tigrisdb.EncodeCollName(collection)
+
 	err = dbPool.Driver.UseDatabase(db).DropCollection(ctx, collection)
 	switch err := err.(type) {
 	case nil:
 		// do nothing
 	case *driver.Error:
-		if tigrisdb.IsNotFound(err) {
-			return nil, common.NewCommandErrorMsg(common.ErrNamespaceNotFound, "ns not found")
+		if !tigrisdb.IsNotFound(err) {
+			return nil, lazyerrors.Error(err)
 		}
-		return nil, lazyerrors.Error(err)
 	default:
 		return nil, lazyerrors.Error(err)
 	}

--- a/internal/handlers/tigris/msg_listcollections.go
+++ b/internal/handlers/tigris/msg_listcollections.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
+	"github.com/FerretDB/FerretDB/internal/handlers/tigris/tigrisdb"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -66,6 +67,8 @@ func (h *Handler) MsgListCollections(ctx context.Context, msg *wire.OpMsg) (*wir
 
 	collections := types.MakeArray(len(names))
 	for _, n := range names {
+		n = tigrisdb.DecodeCollName(n)
+
 		d := must.NotFail(types.NewDocument(
 			"name", n,
 			"type", "collection",

--- a/internal/handlers/tigris/tigrisdb/insert.go
+++ b/internal/handlers/tigris/tigrisdb/insert.go
@@ -37,20 +37,7 @@ func (tdb *TigrisDB) InsertManyDocuments(ctx context.Context, db, collection str
 		return nil
 	}
 
-	if ok, _ := tdb.CollectionExists(ctx, db, collection); !ok {
-		doc := must.NotFail(docs.Get(0)).(*types.Document)
-
-		schema, err := tjson.DocumentSchema(doc)
-		if err != nil {
-			return lazyerrors.Error(err)
-		}
-		schema.Title = collection
-		b := must.NotFail(schema.Marshal())
-
-		if _, err := tdb.CreateCollectionIfNotExist(ctx, db, collection, b); err != nil {
-			return lazyerrors.Error(err)
-		}
-	}
+	collection = EncodeCollName(collection)
 
 	iter := docs.Iterator()
 	defer iter.Close()
@@ -81,11 +68,25 @@ func (tdb *TigrisDB) InsertManyDocuments(ctx context.Context, db, collection str
 		insertDocs[i] = b
 	}
 
-	if _, err := tdb.Driver.UseDatabase(db).Insert(ctx, collection, insertDocs); err != nil {
+	if _, err := tdb.Driver.UseDatabase(db).Insert(ctx, collection, insertDocs); err == nil ||
+		(!IsNotFound(err) && !IsInvalidArgument(err)) {
+		return err
+	}
+
+	doc := must.NotFail(docs.Get(0)).(*types.Document)
+
+	schema, err := tjson.DocumentSchema(doc)
+	if err != nil {
 		return lazyerrors.Error(err)
 	}
 
-	return nil
+	if _, err = tdb.CreateOrUpdateCollection(ctx, db, collection, schema); err != nil && !IsAlreadyExists(err) {
+		return lazyerrors.Error(err)
+	}
+
+	_, err = tdb.Driver.UseDatabase(db).Insert(ctx, collection, insertDocs)
+
+	return err
 }
 
 // InsertDocument inserts a document into FerretDB database and collection.
@@ -96,19 +97,24 @@ func (tdb *TigrisDB) InsertDocument(ctx context.Context, db, collection string, 
 		return err
 	}
 
+	collection = EncodeCollName(collection)
+
+	b, err := tjson.Marshal(doc)
+	if err != nil {
+		return lazyerrors.Error(err)
+	}
+
+	if _, err = tdb.Driver.UseDatabase(db).Insert(ctx, collection, []driver.Document{b}); err == nil ||
+		(!IsNotFound(err) && !IsInvalidArgument(err)) {
+		return err
+	}
+
 	schema, err := tjson.DocumentSchema(doc)
 	if err != nil {
 		return lazyerrors.Error(err)
 	}
-	schema.Title = collection
-	b := must.NotFail(schema.Marshal())
 
-	if _, err := tdb.CreateCollectionIfNotExist(ctx, db, collection, b); err != nil {
-		return lazyerrors.Error(err)
-	}
-
-	b, err = tjson.Marshal(doc)
-	if err != nil {
+	if _, err = tdb.CreateOrUpdateCollection(ctx, db, collection, schema); err != nil && !IsAlreadyExists(err) {
 		return lazyerrors.Error(err)
 	}
 

--- a/internal/handlers/tigris/tigrisdb/stats.go
+++ b/internal/handlers/tigris/tigrisdb/stats.go
@@ -30,6 +30,8 @@ type CollectionStats struct {
 
 // FetchStats returns a set of statistics for the given database and collection.
 func FetchStats(ctx context.Context, db driver.Database, collection string) (*CollectionStats, error) {
+	collection = EncodeCollName(collection)
+
 	info, err := db.DescribeCollection(ctx, collection)
 	switch err := err.(type) {
 	case nil:

--- a/internal/handlers/tigris/tigrisdb/tigrisdb_test.go
+++ b/internal/handlers/tigris/tigrisdb/tigrisdb_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"go.uber.org/zap"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/tigris/tjson"
+	"github.com/FerretDB/FerretDB/internal/types"
+	"github.com/FerretDB/FerretDB/internal/util/must"
 	"github.com/FerretDB/FerretDB/internal/util/testutil"
 )
 
@@ -46,16 +49,16 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 		dbName := testutil.DatabaseName(t)
 		collName := testutil.CollectionName(t)
 
+		_, _ = tdb.Driver.DeleteProject(ctx, dbName)
+
 		t.Cleanup(func() {
 			_, e := tdb.Driver.DeleteProject(ctx, dbName)
 			require.NoError(t, e)
 		})
 
-		schema := driver.Schema(strings.TrimSpace(fmt.Sprintf(
-			`{"title": "%s","properties": {"_id": {"type": "string","format": "byte"}},"primary_key": ["_id"]}`,
-			collName,
-		)))
-		created, err := tdb.CreateCollectionIfNotExist(ctx, dbName, collName, schema)
+		schema := must.NotFail(tjson.DocumentSchema(must.NotFail(types.NewDocument("_id", types.NewObjectID()))))
+		schema.Title = collName
+		created, err := tdb.CreateOrUpdateCollection(ctx, dbName, collName, schema)
 		require.NoError(t, err)
 		assert.True(t, created)
 
@@ -67,6 +70,8 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 
 		dbName := testutil.DatabaseName(t)
 		collName := testutil.CollectionName(t)
+
+		_, _ = tdb.Driver.DeleteProject(ctx, dbName)
 
 		_, err := tdb.Driver.CreateProject(ctx, dbName)
 		require.NoError(t, err)
@@ -80,11 +85,9 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, created)
 
-		schema := driver.Schema(strings.TrimSpace(fmt.Sprintf(
-			`{"title": "%s","properties": {"_id": {"type": "string","format": "byte"}},"primary_key": ["_id"]}`,
-			collName,
-		)))
-		created, err = tdb.CreateCollectionIfNotExist(ctx, dbName, collName, schema)
+		schema := must.NotFail(tjson.DocumentSchema(must.NotFail(types.NewDocument("_id", types.NewObjectID()))))
+		schema.Title = collName
+		created, err = tdb.CreateOrUpdateCollection(ctx, dbName, collName, schema)
 		require.NoError(t, err)
 		assert.True(t, created)
 	})
@@ -94,6 +97,8 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 
 		dbName := testutil.DatabaseName(t)
 		collName := testutil.CollectionName(t)
+
+		_, _ = tdb.Driver.DeleteProject(ctx, dbName)
 
 		_, err := tdb.Driver.CreateProject(ctx, dbName)
 		require.NoError(t, err)
@@ -113,7 +118,9 @@ func TestCreateCollectionIfNotExist(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, created)
 
-		created, err = tdb.CreateCollectionIfNotExist(ctx, dbName, collName, schema)
+		schema1 := must.NotFail(tjson.DocumentSchema(must.NotFail(types.NewDocument("_id", types.NewObjectID()))))
+		schema1.Title = collName
+		created, err = tdb.CreateOrUpdateCollection(ctx, dbName, collName, schema1)
 		require.NoError(t, err)
 		assert.False(t, created)
 	})

--- a/internal/handlers/tigris/tjson/array.go
+++ b/internal/handlers/tigris/tjson/array.go
@@ -51,13 +51,13 @@ func (a *arrayType) UnmarshalJSONWithSchema(data []byte, schema *Schema) error {
 		return lazyerrors.Error(err)
 	}
 
-	if len(rawMessages) > 0 && schema.Items == nil {
-		return lazyerrors.Errorf("tjson.arrayType.UnmarshalJSON: array schema is nil for non-empty array")
-	}
-
 	ta := types.MakeArray(len(rawMessages))
 
 	for _, el := range rawMessages {
+		if schema.Items == nil && !bytes.Equal(data, []byte("null")) {
+			return lazyerrors.Errorf("tjson.arrayType.UnmarshalJSON: array schema is nil for non-empty array")
+		}
+
 		v, err := Unmarshal(el, schema.Items)
 		if err != nil {
 			return lazyerrors.Error(err)

--- a/internal/handlers/tigris/tjson/schema.go
+++ b/internal/handlers/tigris/tjson/schema.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/FerretDB/FerretDB/internal/handlers/commonerrors"
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -338,7 +339,9 @@ func arraySchema(a *types.Array) (*Schema, error) {
 		}
 
 		if !previousSchema.Equal(currentSchema) {
-			return nil, lazyerrors.Errorf("can't set schema for an array with different types")
+			return nil, commonerrors.NewCommandErrorMsg(commonerrors.ErrDocumentValidationFailure,
+				lazyerrors.Errorf("can't set schema for an array with different types").Error(),
+			)
 		}
 	}
 


### PR DESCRIPTION
Fixes major categories of 'dance' tests issues.

* Make schema optional
* Support collection names with slashes and dashes
* Support key names with dashes, dots, beginning with a digit.
* Removed call to DescribeCollection on every request in:
   * Write APIs by evolving the schema from the incoming document
   * In read requests by caching the schema.
