### PR TITLE
Set of fixes

### DIFF
--- a/build/deps/tigris.Dockerfile
+++ b/build/deps/tigris.Dockerfile
@@ -1,1 +1,1 @@
-FROM tigrisdata/tigris-local:1.0.0-beta.52
+FROM tigrisdata/tigris-local:1.0.0-beta.56

--- a/internal/handlers/tigris/json_schema.go
+++ b/internal/handlers/tigris/json_schema.go
@@ -15,18 +15,17 @@
 package tigris
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 
 	"github.com/FerretDB/FerretDB/internal/handlers/common"
 	"github.com/FerretDB/FerretDB/internal/handlers/tigris/tigrisdb"
 	"github.com/FerretDB/FerretDB/internal/handlers/tigris/tjson"
 	"github.com/FerretDB/FerretDB/internal/types"
-	"github.com/FerretDB/FerretDB/internal/util/must"
 )
 
 // getJSONSchema returns a marshaled JSON schema received from validator -> $jsonSchema.
-func getJSONSchema(doc *types.Document, collection string) (*tjson.Schema, error) {
+func getJSONSchema(tdb *tigrisdb.TigrisDB, doc *types.Document, db string, collection string) (*tjson.Schema, error) {
 	collection = tigrisdb.EncodeCollName(collection)
 
 	v, err := common.GetOptionalParam[*types.Document](doc, "validator", types.MakeDocument(0))
@@ -34,9 +33,14 @@ func getJSONSchema(doc *types.Document, collection string) (*tjson.Schema, error
 		return nil, err
 	}
 
-	schema, err := common.GetOptionalParam[string](v, "$tigrisSchemaString", string(getEmptySchema(collection)))
+	schema, err := common.GetRequiredParam[string](v, "$tigrisSchemaString")
 	if err != nil {
-		return nil, err
+		tSchema, err1 := tdb.RefreshCollectionSchema(context.TODO(), db, collection)
+		if err1 != nil {
+			return nil, err1
+		}
+
+		return tSchema, nil
 	}
 
 	if schema == "" {
@@ -51,11 +55,4 @@ func getJSONSchema(doc *types.Document, collection string) (*tjson.Schema, error
 	}
 
 	return sch, nil
-}
-
-func getEmptySchema(collection string) []byte {
-	schema := must.NotFail(tjson.DocumentSchema(must.NotFail(types.NewDocument("_id", types.NewObjectID()))))
-	schema.Title = collection
-
-	return must.NotFail(json.Marshal(schema))
 }

--- a/internal/handlers/tigris/msg_create.go
+++ b/internal/handlers/tigris/msg_create.go
@@ -84,7 +84,7 @@ func (h *Handler) MsgCreate(ctx context.Context, msg *wire.OpMsg) (*wire.OpMsg, 
 	}
 
 	// Validator is required for Tigris as we always need to set schema to create a collection.
-	schema, err := getJSONSchema(document, collection)
+	schema, err := getJSONSchema(dbPool, document, db, collection)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/tigris/tigrisdb/errors.go
+++ b/internal/handlers/tigris/tigrisdb/errors.go
@@ -46,7 +46,7 @@ func IsInvalidArgument(err error) bool {
 func IsNotFound(err error) bool {
 	var driverErr *driver.Error
 	if !errors.As(err, &driverErr) {
-		panic(fmt.Sprintf("unexpected error type %#v", err))
+		return false
 	}
 
 	return driverErr.Code == errNotFound
@@ -56,7 +56,7 @@ func IsNotFound(err error) bool {
 func IsAlreadyExists(err error) bool {
 	var driverErr *driver.Error
 	if !errors.As(err, &driverErr) {
-		panic(fmt.Sprintf("unexpected error type %#v", err))
+		return false
 	}
 
 	return driverErr.Code == errAlreadyExists

--- a/internal/handlers/tigris/tigrisdb/insert.go
+++ b/internal/handlers/tigris/tigrisdb/insert.go
@@ -17,6 +17,8 @@ package tigrisdb
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/tigrisdata/tigris-client-go/driver"
 
@@ -75,8 +77,12 @@ func (tdb *TigrisDB) InsertManyDocuments(ctx context.Context, db, collection str
 
 	doc := must.NotFail(docs.Get(0)).(*types.Document)
 
-	schema, err := tjson.DocumentSchema(doc)
+	schema, err := tdb.RefreshCollectionSchema(ctx, db, collection)
 	if err != nil {
+		return lazyerrors.Error(err)
+	}
+
+	if err = tjson.MergeDocumentSchema(schema, doc); err != nil {
 		return lazyerrors.Error(err)
 	}
 
@@ -109,16 +115,55 @@ func (tdb *TigrisDB) InsertDocument(ctx context.Context, db, collection string, 
 		return err
 	}
 
-	schema, err := tjson.DocumentSchema(doc)
+	schema, err := tdb.RefreshCollectionSchema(ctx, db, collection)
 	if err != nil {
 		return lazyerrors.Error(err)
 	}
 
-	if _, err = tdb.CreateOrUpdateCollection(ctx, db, collection, schema); err != nil && !IsAlreadyExists(err) {
+	if err = tjson.MergeDocumentSchema(schema, doc); err != nil {
 		return lazyerrors.Error(err)
+	}
+
+	if _, err = tdb.CreateOrUpdateCollection(ctx, db, collection, schema); err != nil {
+		if IsInvalidArgument(err) && strings.HasPrefix(err.Error(), "data type mismatch for field \"") {
+			keyPath := strings.TrimPrefix(strings.TrimSuffix(err.Error(), `"`), `data type mismatch for field "`)
+			if !strings.Contains(keyPath, ".") {
+				return lazyerrors.Error(err)
+			}
+
+			keyParts := strings.Split(keyPath, ".")
+			if err = convertToMap(keyParts, schema); err != nil {
+				return lazyerrors.Error(err)
+			}
+
+			if _, err = tdb.CreateOrUpdateCollection(ctx, db, collection, schema); err != nil {
+				return lazyerrors.Error(err)
+			}
+		} else {
+			return lazyerrors.Error(err)
+		}
 	}
 
 	_, err = tdb.Driver.UseDatabase(db).Insert(ctx, collection, []driver.Document{b})
 
 	return err
+}
+
+func convertToMap(keyParts []string, schema *tjson.Schema) error {
+	for i := 0; i < len(keyParts)-1; i++ {
+		v := keyParts[i]
+
+		p := schema.Properties[v]
+		if p.Type != tjson.Object {
+			return fmt.Errorf("expected object type in schema. field %v got %v", v, p.Type)
+		}
+
+		schema = p
+	}
+
+	b := true
+	schema.AdditionalProperties = &b
+	delete(schema.Properties, keyParts[len(keyParts)-1])
+
+	return nil
 }

--- a/internal/handlers/tigris/tigrisdb/query_iterator.go
+++ b/internal/handlers/tigris/tigrisdb/query_iterator.go
@@ -112,6 +112,8 @@ func (iter *queryIterator) Next() (struct{}, *types.Document, error) {
 		switch {
 		case err == nil:
 			// nothing
+		case IsNotFound(err):
+			// Collection or project doesn't exist
 		case IsInvalidArgument(err):
 			// Skip errors from filtering different types.
 			// For example, given document {v: 42} and filter {v: "42"},

--- a/internal/handlers/tigris/tigrisdb/update.go
+++ b/internal/handlers/tigris/tigrisdb/update.go
@@ -43,8 +43,12 @@ func (tdb *TigrisDB) ReplaceDocument(ctx context.Context, db, collection string,
 		return err
 	}
 
-	schema, err := tjson.DocumentSchema(doc)
+	schema, err := tdb.RefreshCollectionSchema(ctx, db, collection)
 	if err != nil {
+		return lazyerrors.Error(err)
+	}
+
+	if err = tjson.MergeDocumentSchema(schema, doc); err != nil {
 		return lazyerrors.Error(err)
 	}
 

--- a/internal/handlers/tigris/tjson/document.go
+++ b/internal/handlers/tigris/tjson/document.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AlekSi/pointer"
+
 	"github.com/FerretDB/FerretDB/internal/types"
 	"github.com/FerretDB/FerretDB/internal/util/lazyerrors"
 	"github.com/FerretDB/FerretDB/internal/util/must"
@@ -61,7 +63,8 @@ func (doc *documentType) UnmarshalJSONWithSchema(data []byte, schema *Schema) er
 	if err := json.Unmarshal(b, &keys); err != nil {
 		return lazyerrors.Error(err)
 	}
-	if len(keys)+1 != len(rawMessages) {
+
+	if len(keys)+1 != len(rawMessages) && (schema.AdditionalProperties == nil || !*schema.AdditionalProperties) {
 		return lazyerrors.Errorf(
 			"tjson.documentType.UnmarshalJSONWithSchema: %d elements in $k, %d in total",
 			len(keys), len(rawMessages),
@@ -72,18 +75,33 @@ func (doc *documentType) UnmarshalJSONWithSchema(data []byte, schema *Schema) er
 	for _, key := range keys {
 		b, ok = rawMessages[EncodeKeyName(key)]
 		if !ok {
+			if pointer.Get(schema.AdditionalProperties) {
+				continue
+			}
 			return lazyerrors.Errorf("tjson.documentType.UnmarshalJSONWithSchema: missing key %q", key)
 		}
+
+		var v any
+		var err error
 
 		// If the field is set as null and is not present in the schema, it's a valid case.
 		// If the field is set as something but null and is not present in the schema, we should return an error.
 		s := schema.Properties[key]
 		if s == nil && !bytes.Equal(b, []byte("null")) {
-			return lazyerrors.Errorf("tjson.documentType.UnmarshalJSONWithSchema: no schema for key %q", key)
-		}
-		v, err := Unmarshal(b, s)
-		if err != nil {
-			return lazyerrors.Error(err)
+			if !pointer.Get(schema.AdditionalProperties) {
+				return lazyerrors.Errorf("tjson.documentType.UnmarshalJSONWithSchema: no schema for key %q", key)
+			}
+
+			if err = json.Unmarshal(b, &v); err != nil {
+				return lazyerrors.Errorf("tjson.documentType.UnmarshalJSONWithSchema: no schema for key %q", key)
+			}
+
+			v = types.ConvertJSON(v)
+		} else {
+			v, err = Unmarshal(b, s)
+			if err != nil {
+				return lazyerrors.Error(err)
+			}
 		}
 
 		td.Set(key, v)

--- a/internal/handlers/tigris/tjson/schema.go
+++ b/internal/handlers/tigris/tjson/schema.go
@@ -68,6 +68,11 @@ type Schema struct {
 	Properties map[string]*Schema `json:"properties,omitempty"`
 	Items      *Schema            `json:"items,omitempty"`
 	PrimaryKey []string           `json:"primary_key,omitempty"`
+	MaxLength  int                `json:"maxLength,omitempty"`
+	MaxItems   *int               `json:"maxItems,omitempty"`
+
+	AdditionalProperties *bool `json:"additionalProperties,omitempty"`
+	SearchIndex          *bool `json:"searchIndex,omitempty"`
 
 	// those fields are not used, but required to be there for DisallowUnknownFields
 	Description    string `json:"description,omitempty"`
@@ -204,6 +209,7 @@ func (s *Schema) Marshal() ([]byte, error) {
 func (s *Schema) Unmarshal(b []byte) error {
 	r := bytes.NewReader(b)
 	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
 
 	if err := dec.Decode(s); err != nil {
 		return err
@@ -271,27 +277,36 @@ func DocumentSchema(doc *types.Document) (*Schema, error) {
 		return nil, lazyerrors.New("document must have an _id")
 	}
 
-	return subdocumentSchema(doc, "_id")
+	schema := &Schema{
+		Type:       Object,
+		Properties: make(map[string]*Schema, doc.Len()+1),
+		PrimaryKey: []string{"_id"},
+	}
+
+	if err := MergeDocumentSchema(schema, doc); err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+// MergeDocumentSchema merges existing schema with document schema.
+func MergeDocumentSchema(schema *Schema, doc *types.Document) error {
+	return subdocumentSchema(schema, doc)
 }
 
 // subdocumentSchema returns a JSON Schema for the given subdocument.
 // Subdocument is a "nested" document that can be used as a property of another document or subdocument.
 // The difference between subdocument and document is that subdocument doesn't have to contain the _id key.
-func subdocumentSchema(doc *types.Document, pkey ...string) (*Schema, error) {
-	schema := Schema{
-		Type:       Object,
-		Properties: make(map[string]*Schema, doc.Len()+1),
-		PrimaryKey: pkey,
-	}
-
+func subdocumentSchema(schema *Schema, doc *types.Document) error {
 	schema.Properties["$k"] = &Schema{Type: Array, Items: stringSchema}
 
 	for _, k := range doc.Keys() {
 		v := must.NotFail(doc.Get(k))
 
-		s, err := valueSchema(v)
+		s, err := valueSchema(schema.Properties[k], v)
 		if err != nil {
-			return nil, lazyerrors.Error(err)
+			return lazyerrors.Error(err)
 		}
 
 		// If s == nil it's a field with null, according to Tigris' logic, we don't set schema for this field.
@@ -300,28 +315,30 @@ func subdocumentSchema(doc *types.Document, pkey ...string) (*Schema, error) {
 		}
 	}
 
-	return &schema, nil
+	return nil
 }
 
 // arraySchema returns a JSON Schema for the given array.
 //
 // Schema can be set successfully only if all the array elements have the same type.
 // If the array is empty, Schema's Type will be set to Array and Items will be nil.
-func arraySchema(a *types.Array) (*Schema, error) {
+func arraySchema(schema *Schema, a *types.Array) (*Schema, error) {
 	if a.Len() == 0 {
+		var i int
 		return &Schema{
-			Type:  Array,
-			Items: nil,
+			Type:     Array,
+			Items:    nil,
+			MaxItems: &i,
 		}, nil
 	}
 
-	previousSchema, err := valueSchema(must.NotFail(a.Get(0)))
+	previousSchema, err := valueSchema(schema, must.NotFail(a.Get(0)))
 	if err != nil {
 		return nil, lazyerrors.Error(err)
 	}
 
 	for i := 1; i < a.Len(); i++ {
-		currentSchema, err := valueSchema(must.NotFail(a.Get(i)))
+		currentSchema, err := valueSchema(schema, must.NotFail(a.Get(i)))
 		if err != nil {
 			return nil, lazyerrors.Error(err)
 		}
@@ -351,12 +368,32 @@ func arraySchema(a *types.Array) (*Schema, error) {
 }
 
 // valueSchema returns a schema for the given value.
-func valueSchema(v any) (*Schema, error) {
+func valueSchema(schema *Schema, v any) (*Schema, error) {
 	switch v := v.(type) {
 	case *types.Document:
-		return subdocumentSchema(v)
+		if schema == nil {
+			schema = &Schema{
+				Type:       Object,
+				Properties: make(map[string]*Schema, v.Len()+1),
+			}
+		} else if schema.Type != Object {
+			return nil, commonerrors.NewCommandErrorMsg(commonerrors.ErrDocumentValidationFailure,
+				lazyerrors.Errorf("can't set schema for an object with different types").Error(),
+			)
+		}
+
+		if schema.SearchIndex == nil {
+			b1 := false
+			schema.SearchIndex = &b1
+		}
+
+		if err := subdocumentSchema(schema, v); err != nil {
+			return nil, err
+		}
+
+		return schema, nil
 	case *types.Array:
-		return arraySchema(v)
+		return arraySchema(schema, v)
 	case float64:
 		return doubleSchema, nil
 	case string:
@@ -383,4 +420,12 @@ func valueSchema(v any) (*Schema, error) {
 	default:
 		panic(fmt.Sprintf("not reached: %T", v))
 	}
+}
+
+// GetEmptySchema returns schema with just ObjectID.
+func GetEmptySchema(collection string) []byte {
+	schema := must.NotFail(DocumentSchema(must.NotFail(types.NewDocument("_id", types.NewObjectID()))))
+	schema.Title = collection
+
+	return must.NotFail(json.Marshal(schema))
 }

--- a/internal/types/document.go
+++ b/internal/types/document.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/FerretDB/FerretDB/internal/util/iterator"
@@ -413,3 +414,34 @@ func (d *Document) moveIDToTheFirstIndex() {
 var (
 	_ document = (*Document)(nil)
 )
+
+// ConvertJSON transforms decoded JSON map[string]any value into *types.Document.
+func ConvertJSON(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		d := MakeDocument(len(value))
+
+		keys := maps.Keys(value)
+		for _, k := range keys {
+			v := value[k]
+			d.Set(k, ConvertJSON(v))
+		}
+
+		return d
+	case []any:
+		a := MakeArray(len(value))
+		for _, v := range value {
+			a.Append(ConvertJSON(v))
+		}
+
+		return a
+	case nil:
+		return Null
+
+	case float64, string, bool:
+		return value
+
+	default:
+		panic(fmt.Sprintf("unsupported type: %[1]T (%[1]v)", value))
+	}
+}


### PR DESCRIPTION
* Merge existing schema with incoming document instead of
  overwriting.
* Cache schemas, do not read it from the Tigris on every query
* Support persisting empty arrays
* Allow fields to change the type.
  This is done by removing the fields from schema,
  and allowing containing object to contain additional fields.
  On read we unmarshall unknown fields accoring to JSON rules.
