### PR TITLE
Push docker image to Quay.io as well

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           images: |
             ${{ env.DOCKER_REPOSITORY }}
-#            ${{ env.QUAY_REPOSITORY }}
+            ${{ env.QUAY_REPOSITORY }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
Pushing `ferretdb` image to our `quay.io/tigrisdata/ferretdb` repo

Preparation:

- Created public `ferretdb` repository in quay.io/tigrisdata
- Added robot user to the repository with the correct permission
